### PR TITLE
Fix link to Discord channel

### DIFF
--- a/apps/home/src/components/Footer.jsx
+++ b/apps/home/src/components/Footer.jsx
@@ -11,7 +11,7 @@ export function Footer() {
         <div className="flex flex-col items-center border-t border-slate-400/10 py-10 sm:flex-row-reverse sm:justify-between">
           <div className="flex gap-x-6">
             <Link
-              href="https://discord.com/invite/jPAKE7Ur"
+              href="https://discord.gg/rXmpYmCNNA"
               className="group"
               aria-label="RecipeUI on Discord"
             >


### PR DESCRIPTION
I tried https://discord.com/invite/jPAKE7Ur but this link wasn't working. I then saw in [ContactUs.jsx](https://github.com/RecipeUI/RecipeUI/blob/2484d7e14ec711be9406a12c2ba539dcdd44d5d4/apps/home/src/components/ContactUs.jsx#L46) that it must be https://discord.gg/rXmpYmCNNA 🙂